### PR TITLE
non-blocking: solve openmp inconsistency with MPI_REQUEST_NULL

### DIFF
--- a/src/SwitchTopo.cpp
+++ b/src/SwitchTopo.cpp
@@ -8,7 +8,6 @@
 #include "SwitchTopo.hpp"
 #include "Topology.hpp"
 #include "h3lpr/macros.hpp"
-#include <bits/stdc++.h>
 
 using namespace std;
 


### PR DESCRIPTION
origin: the different nature of `MPI_REQUEST_NULL` in `mpich` and `openmpi` causes issues to the default(none) openmp `#pragma` clause.

solution: the declaration of a local variable solves the issue as it can be used in the shared clause easily and removes the need of compiler dependent lines of code