### PR TITLE
fix build on darwin system

### DIFF
--- a/samples/validation/Makefile
+++ b/samples/validation/Makefile
@@ -30,8 +30,8 @@ INC := -I$(SRC_DIR)
 
 #-----------------------------------------------------------------------------
 #---- FLUPS
-FLUPS_INC ?= ../../include
-FLUPS_LIB ?= ../../lib
+FLUPS_INC ?= $(realpath ../../include)
+FLUPS_LIB ?= $(realpath ../../lib)
 INC += -I$(FLUPS_INC)
 
 #---- FFTW


### PR DESCRIPTION
fix the build on darwin (macos) systems.
This fix is only temporary and we should switch to `autotools` to avoid all this boilerplate code.